### PR TITLE
Fix for Issue with Numbers not being recognized with a sign

### DIFF
--- a/src/Basic/index.js
+++ b/src/Basic/index.js
@@ -2,6 +2,9 @@ let { RPN, eval, parse } = require('./shunting')
 
 function evaluate(val) {
     let eqn = val
+    if (eqn[0] == '+' || '-'){
+        eqn = '0'+eqn
+    }
     let rpn = RPN(eqn);
 
     var ans = 'Invalid input';


### PR DESCRIPTION
**Issue:**
https://github.com/maan-patel/advanced-calculator/issues/2

**Fix:**
If there's a sign at the start, assume that there is a zero before it. 